### PR TITLE
Add MCP HTTP protocol support (JSON-RPC 2.0 + SSE)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,213 @@
+# Deployment Instructions: MCP HTTP Protocol Update
+
+## What Changed
+
+New files added to enable MCP HTTP protocol (JSON-RPC 2.0 + SSE):
+- `src/mcp/protocol.ts` - Type definitions
+- `src/mcp/handlers.ts` - MCP method handlers (initialize, tools/list, tools/call)
+- `src/mcp/jsonrpc.ts` - JSON-RPC 2.0 request router
+- `src/mcp/sse.ts` - Server-Sent Events manager
+- `src/server.ts` - Modified to include MCP routes
+
+All existing REST endpoints remain unchanged.
+
+---
+
+## Step-by-Step Remote Server Update
+
+### 1. SSH into the remote server
+
+```bash
+ssh your-user@mcp.knb.bulksource.com
+```
+
+### 2. Navigate to the project directory
+
+```bash
+cd /path/to/wikijs-mcp-server
+```
+
+### 3. Add the fork as remote and pull changes
+
+If the server currently tracks the original repo:
+```bash
+# Add BulkSource fork as a new remote
+git remote add bulksource https://github.com/BulkSource/wikijs-mcp-server.git
+
+# Fetch and checkout the feature branch
+git fetch bulksource
+git checkout -b feature/mcp-http-protocol bulksource/feature/mcp-http-protocol
+```
+
+If the server already uses the BulkSource fork:
+```bash
+git fetch origin
+git checkout feature/mcp-http-protocol
+git pull
+```
+
+### 4. Install dependencies (if any new ones were added)
+
+```bash
+npm install
+```
+
+### 5. Build TypeScript
+
+```bash
+npm run build
+```
+
+This compiles `src/**/*.ts` into `dist/**/*.js`.
+
+### 6. Verify the build succeeded
+
+```bash
+# Check that the new MCP files were compiled
+ls dist/mcp/
+# Should show: protocol.js  handlers.js  jsonrpc.js  sse.js
+```
+
+### 7. Restart the server
+
+```bash
+# If using PM2:
+pm2 restart wikijs-mcp
+
+# If using systemd:
+sudo systemctl restart wikijs-mcp
+
+# If running directly:
+npm run stop
+npm run start
+```
+
+### 8. Verify MCP endpoints are working
+
+```bash
+# Health check
+curl http://localhost:8000/health
+
+# Root info (should show /mcp in endpoints list)
+curl http://localhost:8000/
+
+# Test MCP initialize
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {"name": "test", "version": "1.0"}
+    }
+  }'
+
+# Test tools/list
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list",
+    "params": {}
+  }'
+
+# Test tools/call (list pages)
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "list_pages",
+      "arguments": {"limit": 3}
+    }
+  }'
+
+# Test SSE connection (Ctrl+C to stop)
+curl -N http://localhost:8000/mcp/events
+```
+
+---
+
+## Claude Desktop Configuration
+
+Once the server is verified, team members can add this to their Claude Desktop config:
+
+**File:** `~/.config/claude/claude_desktop_config.json` (Linux/Mac) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
+
+```json
+{
+  "mcpServers": {
+    "wikijs": {
+      "transport": "http",
+      "url": "https://mcp.knb.bulksource.com/mcp",
+      "events": "https://mcp.knb.bulksource.com/mcp/events"
+    }
+  }
+}
+```
+
+## Claude Code CLI Configuration
+
+```bash
+claude mcp add wikijs --transport http --url https://mcp.knb.bulksource.com/mcp
+```
+
+---
+
+## Installing Claude Code CLI on Remote Server
+
+If you want Claude Code to help manage the remote server:
+
+```bash
+# Install via npm (Node.js 18+ required)
+npm install -g @anthropic-ai/claude-code
+
+# Authenticate
+claude login
+
+# Navigate to project and let Claude help
+cd /path/to/wikijs-mcp-server
+claude
+```
+
+---
+
+## Rollback
+
+If something goes wrong:
+```bash
+git checkout main
+npm run build
+# restart server
+```
+
+---
+
+## Reverse Proxy Note
+
+If the server runs behind nginx/Caddy on `mcp.knb.bulksource.com`, ensure:
+- `POST /mcp` is proxied with JSON body support
+- `GET /mcp/events` is proxied with SSE support (no buffering)
+
+Nginx example:
+```nginx
+location /mcp/events {
+    proxy_pass http://localhost:8000;
+    proxy_set_header Connection '';
+    proxy_http_version 1.1;
+    chunked_transfer_encoding off;
+    proxy_buffering off;
+    proxy_cache off;
+}
+
+location /mcp {
+    proxy_pass http://localhost:8000;
+    proxy_set_header Content-Type $http_content_type;
+}
+```

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -1,0 +1,161 @@
+/**
+ * MCP method handlers
+ * Implements initialize, tools/list, tools/call and edge cases
+ * Ported from lib/fixed_mcp_http_server.js
+ */
+
+import { wikiJsTools, wikiJsToolsWithImpl } from "../tools.js";
+import {
+  safeValidateToolParams,
+  safeValidateToolResult,
+} from "../schemas.js";
+import type {
+  McpInitializeResult,
+  McpToolsListResult,
+  McpToolCallResult,
+  McpInitializeParams,
+  McpToolCallParams,
+  ToolImplementation,
+} from "./protocol.js";
+
+// Build tools lookup map from implementations
+const toolsMap: Record<string, ToolImplementation> = {};
+for (const tool of wikiJsToolsWithImpl) {
+  toolsMap[tool.function.name] = tool.implementation;
+}
+
+// Tool names for direct-call routing
+const toolNames = wikiJsTools.map((t) => t.function.name);
+
+// Tools that accept no required params (skip validation for empty args)
+const NO_PARAMS_TOOLS = new Set(["list_users", "list_groups"]);
+
+export class McpHandlers {
+  /**
+   * Handle MCP initialize handshake
+   */
+  handleInitialize(params?: McpInitializeParams): McpInitializeResult {
+    return {
+      protocolVersion: params?.protocolVersion || "2024-11-05",
+      capabilities: {
+        tools: { enabled: true },
+        prompts: { enabled: false },
+        resources: { enabled: false },
+        logging: { enabled: true },
+        roots: { listChanged: false },
+      },
+      serverInfo: {
+        name: "wikijs-mcp",
+        version: "1.3.0",
+      },
+    };
+  }
+
+  /**
+   * Handle tools/list - returns all tools in MCP format
+   */
+  handleToolsList(): McpToolsListResult {
+    const tools = wikiJsTools.map((tool) => ({
+      name: tool.function.name,
+      description: tool.function.description,
+      inputSchema: tool.function.parameters,
+      outputSchema: { type: "object" as const },
+      metadata: {
+        title: tool.function.name
+          .replace(/_/g, " ")
+          .replace(/\b\w/g, (c) => c.toUpperCase()),
+        description: tool.function.description,
+        ui: {
+          icon: "document",
+          ui_type: "default",
+        },
+      },
+    }));
+
+    return { tools };
+  }
+
+  /**
+   * Handle tools/call - execute a tool by name
+   * Ported edge cases: search_users q->query, no-params tools bypass
+   */
+  async handleToolCall(params: McpToolCallParams): Promise<McpToolCallResult> {
+    const toolName = params.name;
+    let args = { ...(params.arguments || {}) };
+
+    console.log(
+      `[MCP] tools/call: ${toolName} with params: ${JSON.stringify(args)}`
+    );
+
+    // Edge case from JS version: Cursor sends 'q' instead of 'query' for search_users
+    if (
+      toolName === "search_users" &&
+      (args as any).q &&
+      !(args as any).query
+    ) {
+      console.log(`[MCP] Remapping param q -> query for search_users`);
+      (args as any).query = (args as any).q;
+      delete (args as any).q;
+    }
+
+    // Find implementation
+    const implementation = toolsMap[toolName];
+    if (!implementation) {
+      throw new Error(`Tool not found: ${toolName}`);
+    }
+
+    // Validate params (skip for no-params tools like list_users, list_groups)
+    let validatedParams = args;
+    if (!NO_PARAMS_TOOLS.has(toolName)) {
+      const validation = safeValidateToolParams(toolName, args);
+      if (validation.success === false) {
+        const errorDetail =
+          typeof validation.error === "object" && "format" in validation.error
+            ? (validation.error as any).format()
+            : validation.error;
+        throw Object.assign(
+          new Error(`Invalid params for ${toolName}`),
+          { code: -32602, data: errorDetail }
+        );
+      }
+      if (validation.success && "data" in validation) {
+        validatedParams = validation.data;
+      }
+    }
+
+    // Execute
+    const result = await implementation(validatedParams);
+
+    // Validate result (warning only, don't block)
+    const resultValidation = safeValidateToolResult(toolName, result);
+    if (resultValidation.success === false) {
+      console.warn(
+        `[MCP] Result validation warning for ${toolName}: ${JSON.stringify(
+          resultValidation.error
+        )}`
+      );
+    }
+
+    console.log(`[MCP] Tool ${toolName} executed successfully`);
+
+    // Format as MCP content
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            typeof result === "string"
+              ? result
+              : JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Check if a method name is a direct tool name (e.g., "get_page" sent as method)
+   */
+  isDirectToolCall(method: string): boolean {
+    return toolNames.includes(method);
+  }
+}

--- a/src/mcp/jsonrpc.ts
+++ b/src/mcp/jsonrpc.ts
@@ -1,0 +1,181 @@
+/**
+ * JSON-RPC 2.0 request router for MCP HTTP transport
+ * Validates incoming requests and routes to appropriate MCP handlers
+ * Ported from lib/fixed_mcp_http_server.js
+ */
+
+import { FastifyRequest, FastifyReply } from "fastify";
+import {
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JSON_RPC_ERRORS,
+} from "./protocol.js";
+import { McpHandlers } from "./handlers.js";
+import { SSEManager } from "./sse.js";
+
+export class JsonRpcRouter {
+  private handlers: McpHandlers;
+  private sse: SSEManager;
+
+  constructor(handlers: McpHandlers, sse: SSEManager) {
+    this.handlers = handlers;
+    this.sse = sse;
+  }
+
+  /**
+   * Handle incoming POST /mcp request
+   */
+  async handle(
+    request: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<JsonRpcResponse> {
+    let parsedBody: JsonRpcRequest;
+
+    try {
+      parsedBody = request.body as JsonRpcRequest;
+    } catch {
+      return this.errorResponse(
+        reply,
+        JSON_RPC_ERRORS.PARSE_ERROR,
+        "Parse error",
+        null
+      );
+    }
+
+    console.log(
+      `[JSON-RPC] ${parsedBody.method} (id: ${parsedBody.id ?? "notification"})`
+    );
+
+    // Validate JSON-RPC 2.0 format
+    if (parsedBody.jsonrpc !== "2.0") {
+      return this.errorResponse(
+        reply,
+        JSON_RPC_ERRORS.INVALID_REQUEST,
+        "Invalid Request: jsonrpc must be '2.0'",
+        parsedBody.id ?? null
+      );
+    }
+
+    try {
+      const result = await this.route(parsedBody.method, parsedBody.params);
+      return this.successResponse(reply, result, parsedBody.id ?? null);
+    } catch (error: any) {
+      const code = error.code || JSON_RPC_ERRORS.INTERNAL_ERROR;
+      const message = error.message || "Internal error";
+      const data = error.data || undefined;
+
+      console.error(`[JSON-RPC] Error in ${parsedBody.method}: ${message}`);
+
+      // Broadcast error via SSE
+      this.sse.broadcast("tool_error", {
+        method: parsedBody.method,
+        error: message,
+      });
+
+      return this.errorResponse(
+        reply,
+        code,
+        message,
+        parsedBody.id ?? null,
+        data
+      );
+    }
+  }
+
+  /**
+   * Route method to appropriate handler
+   * Supports: initialize, tools/list, tools/call, ping,
+   *   workspace/tools, workspace/executeCommand, tools/execute,
+   *   and direct tool calls by name
+   */
+  private async route(method: string, params?: Record<string, any>): Promise<any> {
+    switch (method) {
+      case "initialize":
+        return this.handlers.handleInitialize(params as any);
+
+      case "tools/list":
+      case "workspace/tools":
+        return this.handlers.handleToolsList();
+
+      case "tools/call": {
+        const result = await this.handlers.handleToolCall({
+          name: params?.name,
+          arguments: params?.arguments || {},
+        });
+        this.sse.broadcast("tool_executed", {
+          tool: params?.name,
+          status: "success",
+        });
+        return result;
+      }
+
+      // Legacy Cursor methods
+      case "tools/execute":
+      case "workspace/executeCommand": {
+        const toolName = params?.command || params?.name;
+        const toolArgs = params?.arguments || params?.params || {};
+        const result = await this.handlers.handleToolCall({
+          name: toolName,
+          arguments: toolArgs,
+        });
+        this.sse.broadcast("command_executed", {
+          tool: toolName,
+          status: "success",
+        });
+        return result;
+      }
+
+      case "ping":
+        return {};
+
+      default:
+        // Direct tool call by method name (e.g., method: "get_page")
+        if (this.handlers.isDirectToolCall(method)) {
+          const result = await this.handlers.handleToolCall({
+            name: method,
+            arguments: params || {},
+          });
+          this.sse.broadcast("tool_executed", {
+            tool: method,
+            status: "success",
+          });
+          return result;
+        }
+
+        throw Object.assign(
+          new Error(`Method not found: ${method}`),
+          { code: JSON_RPC_ERRORS.METHOD_NOT_FOUND }
+        );
+    }
+  }
+
+  private successResponse(
+    reply: FastifyReply,
+    result: any,
+    id: string | number | null
+  ): JsonRpcResponse {
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id: id,
+      result,
+    };
+    reply.send(response);
+    return response;
+  }
+
+  private errorResponse(
+    reply: FastifyReply,
+    code: number,
+    message: string,
+    id: string | number | null,
+    data?: any
+  ): JsonRpcResponse {
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id: id,
+      error: { code, message, ...(data !== undefined && { data }) },
+    };
+    reply.send(response);
+    return response;
+  }
+}

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -1,0 +1,108 @@
+/**
+ * MCP Protocol type definitions
+ * JSON-RPC 2.0 + MCP-specific types for HTTP transport
+ */
+
+// ---- JSON-RPC 2.0 ----
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method: string;
+  params?: Record<string, any>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: any;
+  error?: JsonRpcError;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: any;
+}
+
+// Standard JSON-RPC 2.0 error codes
+export const JSON_RPC_ERRORS = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+} as const;
+
+// ---- MCP Protocol ----
+
+export interface McpInitializeParams {
+  protocolVersion: string;
+  capabilities: Record<string, any>;
+  clientInfo: {
+    name: string;
+    version: string;
+  };
+}
+
+export interface McpInitializeResult {
+  protocolVersion: string;
+  capabilities: {
+    tools: { enabled: boolean };
+    prompts: { enabled: boolean };
+    resources: { enabled: boolean };
+    logging: { enabled: boolean };
+    roots?: { listChanged: boolean };
+  };
+  serverInfo: {
+    name: string;
+    version: string;
+  };
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, any>;
+  outputSchema?: Record<string, any>;
+  metadata?: {
+    title: string;
+    description: string;
+    ui: Record<string, any>;
+  };
+}
+
+export interface McpToolsListResult {
+  tools: McpTool[];
+}
+
+export interface McpToolCallParams {
+  name: string;
+  arguments?: Record<string, any>;
+}
+
+export interface McpToolCallResult {
+  content: McpToolContent[];
+  isError?: boolean;
+}
+
+export interface McpToolContent {
+  type: "text" | "image" | "resource";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+// ---- Tool execution types ----
+
+export type ToolImplementation = (params: any) => Promise<any>;
+
+export interface ToolWithImpl {
+  type: string;
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, any>;
+  };
+  implementation: ToolImplementation;
+}

--- a/src/mcp/sse.ts
+++ b/src/mcp/sse.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-Sent Events (SSE) manager for MCP notifications
+ * Ported from lib/fixed_mcp_http_server.js
+ */
+
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export class SSEManager {
+  private clients: Set<FastifyReply> = new Set();
+  private keepAliveIntervals: Map<FastifyReply, NodeJS.Timeout> = new Map();
+
+  /**
+   * Handle a new SSE connection
+   */
+  handleConnection(request: FastifyRequest, reply: FastifyReply): void {
+    // Set SSE headers via raw response
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+
+    // Send initial connected event
+    reply.raw.write("event: connected\ndata: {}\n\n");
+
+    // Register client
+    this.clients.add(reply);
+    console.log(`[SSE] Client connected, active clients: ${this.clients.size}`);
+
+    // Keep-alive ping every 30 seconds
+    const keepAlive = setInterval(() => {
+      reply.raw.write(": keep-alive\n\n");
+    }, 30000);
+    this.keepAliveIntervals.set(reply, keepAlive);
+
+    // Clean up on disconnect
+    request.raw.on("close", () => {
+      this.removeClient(reply);
+      console.log(
+        `[SSE] Client disconnected, active clients: ${this.clients.size}`
+      );
+    });
+  }
+
+  /**
+   * Send an event to all connected clients
+   */
+  broadcast(event: string, data: any): void {
+    const eventString = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const client of this.clients) {
+      try {
+        client.raw.write(eventString);
+      } catch {
+        this.removeClient(client);
+      }
+    }
+  }
+
+  /**
+   * Get the number of connected clients
+   */
+  get clientCount(): number {
+    return this.clients.size;
+  }
+
+  private removeClient(reply: FastifyReply): void {
+    this.clients.delete(reply);
+    const interval = this.keepAliveIntervals.get(reply);
+    if (interval) {
+      clearInterval(interval);
+      this.keepAliveIntervals.delete(reply);
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,9 @@ import { WikiJsApi } from "./api.js";
 import { wikiJsTools } from "./tools.js";
 import { ServerConfig } from "./types.js";
 import { config as dotenvConfig } from "dotenv";
+import { McpHandlers } from "./mcp/handlers.js";
+import { JsonRpcRouter } from "./mcp/jsonrpc.js";
+import { SSEManager } from "./mcp/sse.js";
 
 // Загрузка переменных окружения из .env файла
 dotenvConfig();
@@ -27,6 +30,49 @@ const server = fastify({ logger: true });
 
 // Создание экземпляра API Wiki.js
 const wikiJsApi = new WikiJsApi(config.wikijs.baseUrl, config.wikijs.token);
+
+// ---- MCP HTTP Protocol Setup ----
+const mcpHandlers = new McpHandlers();
+const sseManager = new SSEManager();
+const jsonRpcRouter = new JsonRpcRouter(mcpHandlers, sseManager);
+
+// CORS support for MCP endpoints
+server.addHook("onRequest", async (request, reply) => {
+  reply.header("Access-Control-Allow-Origin", "*");
+  reply.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  reply.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  if (request.method === "OPTIONS") {
+    reply.code(204).send();
+  }
+});
+
+// MCP JSON-RPC 2.0 endpoint
+server.post("/mcp", async (request, reply) => {
+  return jsonRpcRouter.handle(request, reply);
+});
+
+// MCP Server-Sent Events endpoint
+server.get("/mcp/events", async (request, reply) => {
+  sseManager.handleConnection(request, reply);
+  // Don't return — the SSE connection stays open
+  return reply;
+});
+
+// Root endpoint with server info
+server.get("/", async () => {
+  return {
+    status: "ok",
+    message: "Wiki.js MCP Server is running",
+    version: "1.3.0",
+    endpoints: {
+      "/health": "Server health check",
+      "/tools": "List available tools (legacy format)",
+      "/mcp": "MCP JSON-RPC 2.0 endpoint",
+      "/mcp/events": "MCP SSE notifications endpoint",
+    },
+  };
+});
 
 // Маршрут для проверки здоровья сервера
 server.get("/health", async () => {
@@ -302,6 +348,8 @@ const start = async () => {
 
     await server.listen({ port: config.port, host: "0.0.0.0" });
     console.log(`MCP сервер для Wiki.js запущен на порту ${config.port}`);
+    console.log(`MCP JSON-RPC endpoint: http://localhost:${config.port}/mcp`);
+    console.log(`MCP SSE endpoint: http://localhost:${config.port}/mcp/events`);
   } catch (err) {
     server.log.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary

- Add `POST /mcp` JSON-RPC 2.0 endpoint and `GET /mcp/events` SSE endpoint for MCP HTTP transport
- Enable remote Claude Desktop/Code connections without local Node.js installation
- All existing REST routes (`/health`, `/tools`, individual tool endpoints) remain unchanged

## New files

| File | Purpose |
|---|---|
| `src/mcp/protocol.ts` | TypeScript types for JSON-RPC 2.0 and MCP protocol |
| `src/mcp/handlers.ts` | MCP method handlers (initialize, tools/list, tools/call) |
| `src/mcp/jsonrpc.ts` | JSON-RPC 2.0 request validator and router |
| `src/mcp/sse.ts` | Server-Sent Events manager with keep-alive |
| `DEPLOY.md` | Remote server deployment instructions |

## Supported MCP methods

- `initialize` - handshake and capability negotiation
- `tools/list` - list all 17 Wiki.js tools
- `tools/call` - execute any tool
- `ping` - keep-alive
- Legacy Cursor methods: `workspace/tools`, `workspace/executeCommand`, `tools/execute`
- Direct tool calls by method name (e.g., `method: "get_page"`)

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] `curl POST /mcp` with `initialize` returns server capabilities
- [ ] `curl POST /mcp` with `tools/list` returns all 17 tools
- [ ] `curl POST /mcp` with `tools/call` executes a tool against Wiki.js
- [ ] `curl GET /mcp/events` establishes SSE connection
- [ ] Existing `/health` and `/tools` endpoints still work
- [ ] Claude Desktop connects via HTTP transport config

🤖 Generated with [Claude Code](https://claude.com/claude-code)